### PR TITLE
Library upgrade to new play-core versions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,16 +1,22 @@
 ---
 name: Bug report
-about: Create a report to help us improve
+about: Create a bug report to help us improve
 title: ''
 labels: bug
 assignees: adriangl
 
 ---
 
-**Device and SW details (please complete the following information):**
- - Device: [e.g. Google Pixel 3]
- - OS: [e.g. Android 9]
- - Library Version [e.g. 1.0.0]
+**Device and SW details**
+- Device: [e.g. Google Pixel 3]
+- OS: [e.g. Android 9]
+- Library Version [e.g. 1.0.0]
+ 
+**Conditions for the library to work**
+- [ ] I have set the package name of the app to **exactly** the one I'd like to test in-app updates with.
+- [ ] I have signed the app with the same key that I used to sign the app I want to test in-app updates with.
+- [ ] I've ensured that any of my Google accounts in my test device has access to said app in Google Play Store.
+- [ ] The Google Play Store displays updates for the app I want to use to test in-app updates with.
 
 **Summary and background of the bug**
 A clear and concise description of what the bug is.
@@ -18,8 +24,8 @@ A clear and concise description of what the bug is.
 **Steps to reproduce**
 Steps to reproduce the behavior:
 1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
+2. Click on '...'
+3. Scroll down to '...'
 4. See error
 
 Also attach notes or stack traces if applicable.

--- a/.gitignore
+++ b/.gitignore
@@ -40,10 +40,10 @@ captures/
 .idea/dictionaries
 .idea/libraries
 .idea/caches
-.idea/codeStyles
 .idea/modules.xml
 .idea/misc.xml
 .idea/jarRepositories.xml
+.idea/vcs.xml
 
 # Keystore files
 *.jks
@@ -58,3 +58,9 @@ google-services.json
 freeline.py
 freeline/
 freeline_project_description.json
+
+# Signing configurations
+app_config.properties
+
+# Application ID configurations
+app_id.properties

--- a/.gitignore
+++ b/.gitignore
@@ -59,8 +59,5 @@ freeline.py
 freeline/
 freeline_project_description.json
 
-# Signing configurations
+# App configuration properties
 app_config.properties
-
-# Application ID configurations
-app_id.properties

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,134 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <JetCodeStyleSettings>
+      <option name="PACKAGES_TO_USE_STAR_IMPORTS">
+        <value>
+          <package name="java.util" alias="false" withSubpackages="false" />
+          <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
+          <package name="io.ktor" alias="false" withSubpackages="true" />
+        </value>
+      </option>
+      <option name="PACKAGES_IMPORT_LAYOUT">
+        <value>
+          <package name="" alias="false" withSubpackages="true" />
+          <package name="java" alias="false" withSubpackages="true" />
+          <package name="javax" alias="false" withSubpackages="true" />
+          <package name="kotlin" alias="false" withSubpackages="true" />
+          <package name="" alias="true" withSubpackages="true" />
+        </value>
+      </option>
+    </JetCodeStyleSettings>
+    <codeStyleSettings language="XML">
+      <indentOptions>
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      </indentOptions>
+      <arrangement>
+        <rules>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>xmlns:android</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>xmlns:.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:id</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:name</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>name</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>style</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>ANDROID_ATTRIBUTE_ORDER</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>.*</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+        </rules>
+      </arrangement>
+    </codeStyleSettings>
+  </code_scheme>
+</component>

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <bytecodeTargetLevel target="1.8" />
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/README.md
+++ b/README.md
@@ -3,10 +3,12 @@
 
 This utility library aims to help Android developers to use the [Google Play In-App Updates API](https://developer.android.com/guide/app-bundle/in-app-updates) in an easy way.
 
-**It's highly encouraged that you first read the [Google Play In-App Updates API](https://developer.android.com/guide/app-bundle/in-app-updates) documentation before using this library in order to understand the core concepts of the library.**
+> It's highly encouraged that you first read the [Google Play In-App Updates API](https://developer.android.com/guide/app-bundle/in-app-updates) documentation before using this library in order to understand the core concepts of the library.
 
-## Installation
-Add the following dependencies to your main `build.gradle`:
+## Setting Up
+In your main `build.gradle`, add [jitpack.io](https://jitpack.io/) repository in the `allprojects` block:
+
+<details open><summary>Groovy</summary>
 ```groovy
 allprojects {
     repositories {
@@ -14,24 +16,39 @@ allprojects {
     }
 }
 ```
+</details>
 
-Add the following dependencies to your app's `build.gradle`:
-
-* For Gradle < 4.0
-    ```groovy
-    dependencies {
-        compile "com.github.bq:android-app-updates-helper:1.0.2"
+<details><summary>Kotlin</summary>
+```kotlin
+allprojects {
+    repositories {
+        maven(url = "https://jitpack.io")
     }
-    ```
+}
+```
+</details>
 
-* For Gradle 4.0+
-    ```groovy
-    dependencies {
-        implementation "com.github.bq:android-app-updates-helper:1.0.2"
-    }
-    ```
 
-## Example usage
+Add the following dependencies to your app or library's `build.gradle`:
+
+<details open><summary>Groovy</summary>
+```groovy
+dependencies {
+    implementation "com.github.bq:android-app-updates-helper:1.0.2"
+}
+```
+</details>
+
+
+<details open><summary>Kotlin</summary>
+```kotlin
+dependencies {
+    implementation("com.github.bq:android-app-updates-helper:1.0.2")
+}
+```
+</details>
+
+## How to use
 * Create a new _AppUpdatesHelper_.
 * Start listening for app update changes with _AppUpdatesHelper.startListening()_, for example in _onCreate()_.
 * Stop listening for app update changes with _AppUpdatesHelper.stopListening()_ in _onDestroy()_.
@@ -41,18 +58,37 @@ Add the following dependencies to your app's `build.gradle`:
 Check the [example app](app) for more implementation details about [flexible](app/src/main/kotlin/com/bq/appupdateshelper/flexible/FlexibleUpdateActivity.kt)
 and [immediate](app/src/main/kotlin/com/bq/appupdateshelper/immediate/ImmediateUpdateActivity.kt) updates. 
 
-If you use the example app, don't forget the following things when testing:
-* Change the package name of the example app to the one you'd like to test in-app updates with.
-* Sign the example app with the same keys that you used to sign the app you want to test in-app updates with.
-* If the app is not published yet, or you want to test with internal app sharing or closed tracks, ensure that any of your Google accounts in your device has access to said app in Google Play Store.
-
 You can also use a [fake implementation](app/src/main/kotlin/com/bq/appupdateshelper/fake/FakeUpdateActivity.kt) to test in-app updates.
 
+Keep in mind that you may not see in-app updates if these conditions don't match:
+* The package name of the app is **exactly** the one you'd like to test in-app updates with.
+* The app must be signed with the same keys that you used to sign the app you want to test in-app updates with.
+* If the app is not published yet or you want to test with internal app sharing or closed tracks, 
+ensure that any of your Google accounts in your device has access to said app in Google Play Store.
+* Check if the Google Play Store displays updates for the app you want to use to test in-app updates.
+
+Please ensure that all conditions apply when using this library in order to avoid unnecessary headaches.
+
+### Using the example app
+In order to ease using the example app with the sample data of your own app, 
+you can create an `app_config.properties` file in the root of the project with the following content:
+```properties
+applicationId=your.application.id
+keystorePath=/full/path/to/your/keystore/file
+keystorePwd=your_keystore_password
+keystoreAlias=your_keystore_alias
+keystoreAliasPwd=your_keystore_alias_password
+```
+
+These values will be picked up by the compilation process of the example app 
+and will set the application ID and signing configurations for you.
+
 ## Authors & Collaborators
-* [Adrián García](https://github.com/adriangl) - Author and maintainer
-* [Daniel Sánchez Ceinos](https://github.com/danielceinos) - Contributor
+* **[Adrián García](https://github.com/adriangl)** - *Author and maintainer*
+* **[Daniel Sánchez Ceinos](https://github.com/danielceinos)** - *Contributor*
 
 ## License
+This project is licensed under the Apache Software License, Version 2.0.
 ```
 Copyright (C) 2019 BQ
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This utility library aims to help Android developers to use the [Google Play In-
 In your main `build.gradle`, add [jitpack.io](https://jitpack.io/) repository in the `allprojects` block:
 
 <details open><summary>Groovy</summary>
+
 ```groovy
 allprojects {
     repositories {
@@ -19,6 +20,7 @@ allprojects {
 </details>
 
 <details><summary>Kotlin</summary>
+
 ```kotlin
 allprojects {
     repositories {
@@ -32,6 +34,7 @@ allprojects {
 Add the following dependencies to your app or library's `build.gradle`:
 
 <details open><summary>Groovy</summary>
+
 ```groovy
 dependencies {
     implementation "com.github.bq:android-app-updates-helper:1.0.2"
@@ -41,6 +44,7 @@ dependencies {
 
 
 <details><summary>Kotlin</summary>
+
 ```kotlin
 dependencies {
     implementation("com.github.bq:android-app-updates-helper:1.0.2")
@@ -50,14 +54,13 @@ dependencies {
 
 You'll also need to add support for Java 8 in your project. To do so:
 <details open><summary>Groovy</summary>
+
 ```groovy
 android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
-
-    // In Kotlin projects
     kotlinOptions {
         jvmTarget = "1.8"
     }
@@ -66,13 +69,13 @@ android {
 </details>
 
 <details><summary>Kotlin</summary>
+
 ```kotlin
 android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
     }
-
     kotlinOptions {
         jvmTarget = "1.8"
     }
@@ -82,8 +85,8 @@ android {
 
 ## How to use
 * Create a new _AppUpdatesHelper_.
-* Start listening for app update changes with _AppUpdatesHelper.startListening()_, for example in _onCreate()_.
-* Stop listening for app update changes with _AppUpdatesHelper.stopListening()_ in _onDestroy()_.
+* Start listening for app update changes with _AppUpdatesHelper.startListening()_, for example in _Activity.onCreate()_ or in _Fragment.onViewCreated()_.
+* Stop listening for app update changes with _AppUpdatesHelper.stopListening()_ in _Activity.onDestroy()_ or in _Fragment.onDestroyView()_.
 * Request app update information with _AppUpdatesHelper.getAppUpdateInfo()_.
 * Request a flexible or immediate update with _AppUpdatesHelper.startFlexibleUpdate()_ or _AppUpdatesHelper.startImmediateUpdate()_
 

--- a/README.md
+++ b/README.md
@@ -40,10 +40,42 @@ dependencies {
 </details>
 
 
-<details open><summary>Kotlin</summary>
+<details><summary>Kotlin</summary>
 ```kotlin
 dependencies {
     implementation("com.github.bq:android-app-updates-helper:1.0.2")
+}
+```
+</details>
+
+You'll also need to add support for Java 8 in your project. To do so:
+<details open><summary>Groovy</summary>
+```groovy
+android {
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    // In Kotlin projects
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+}
+```
+</details>
+
+<details><summary>Kotlin</summary>
+```kotlin
+android {
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
 }
 ```
 </details>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,21 +21,65 @@ apply plugin: 'kotlin-android-extensions'
 
 apply plugin: 'com.gladed.androidgitversion'
 
+apply from: "$rootDir/gradle/properties_utils.gradle"
+
+ext {
+    /*
+     ********************
+     * Android variables
+     ********************
+     */
+    compile_sdk_version = 30
+    min_sdk_version = 21
+    target_sdk_version = 30
+    build_tools_version = "30.0.2"
+}
+
 android {
-    compileSdkVersion project.ext.compileSdkVersion
+    compileSdkVersion compile_sdk_version
+    buildToolsVersion build_tools_version
 
     defaultConfig {
-        applicationId "com.bq.appupdateshelper" // Fake, replace with your own
-        minSdkVersion project.ext.minSdkVersion
-        targetSdkVersion project.ext.targetSdkVersion
+        /*
+         * Change your application ID to the app you want to test with
+         *
+         * Requires configuration via app_config.properties file or injected via environment variables.
+         * The loadEnvOrProperty will try to find the environment variable (in snake_case) or the
+         * property in signing.properties (converted to camelCase)
+         */
+        applicationId loadEnvOrProperty("APPLICATION_ID", "/", "app_config.properties")
+        minSdkVersion min_sdk_version
+        targetSdkVersion target_sdk_version
         versionCode 1
         versionName androidGitVersion.name()
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
+
+    signingConfigs {
+        /*
+         * Local release signing configuration
+         *
+         * Requires configuration via app_config.properties file or injected via environment variables.
+         * The loadEnvOrProperty will try to find the environment variable (in snake_case) or the
+         * property in signing.properties (converted to camelCase)
+         */
+        localRelease {
+            storeFile file(loadEnvOrProperty("KEYSTORE_PATH", "/", "app_config.properties"))
+            storePassword loadEnvOrProperty("KEYSTORE_PWD", "", "app_config.properties")
+            keyAlias loadEnvOrProperty("KEYSTORE_ALIAS", "", "app_config.properties")
+            keyPassword loadEnvOrProperty("KEYSTORE_ALIAS_PWD", "", "app_config.properties")
+        }
+    }
+
     buildTypes {
+        debug {
+            signingConfig signingConfigs.localRelease
+        }
+
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            signingConfig signingConfigs.localRelease
         }
     }
 
@@ -48,15 +92,15 @@ dependencies {
     implementation project(":lib")
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
-    implementation 'androidx.appcompat:appcompat:1.0.2'
-    implementation 'androidx.core:core-ktx:1.0.2'
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'androidx.core:core-ktx:1.3.2'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.2'
 
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.13'
 
-    androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
-    implementation 'com.google.android.material:material:1.0.0'
+    androidTestImplementation 'androidx.test:runner:1.3.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+    implementation 'com.google.android.material:material:1.2.1'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -55,6 +55,10 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
+    buildFeatures {
+        viewBinding true
+    }
+
     signingConfigs {
         /*
          * Local release signing configuration

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -90,6 +90,15 @@ android {
     sourceSets.all {
         java.srcDirs += "src/${name}/kotlin"
     }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
 }
 
 dependencies {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:tools="http://schemas.android.com/tools"
-          package="com.bq.appupdateshelper">
+          package="com.bq.appupdateshelper_app">
 
     <application
         android:allowBackup="false"
@@ -12,18 +12,18 @@
         android:theme="@style/AppTheme"
         tools:ignore="GoogleAppIndexingWarning">
 
-        <activity android:name="com.bq.appupdateshelper.MainActivity">
+        <activity android:name=".MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
 
-        <activity android:name="com.bq.appupdateshelper.immediate.ImmediateUpdateActivity"/>
+        <activity android:name=".immediate.ImmediateUpdateActivity"/>
 
-        <activity android:name="com.bq.appupdateshelper.flexible.FlexibleUpdateActivity"/>
+        <activity android:name=".flexible.FlexibleUpdateActivity"/>
 
-        <activity android:name="com.bq.appupdateshelper.fake.FakeUpdateActivity"/>
+        <activity android:name=".fake.FakeUpdateActivity"/>
 
     </application>
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,6 +23,8 @@
 
         <activity android:name=".flexible.FlexibleUpdateActivity"/>
 
+        <activity android:name=".fragment.FragmentUpdateActivity"/>
+
         <activity android:name=".fake.FakeUpdateActivity"/>
 
     </application>

--- a/app/src/main/kotlin/com/bq/appupdateshelper_app/MainActivity.kt
+++ b/app/src/main/kotlin/com/bq/appupdateshelper_app/MainActivity.kt
@@ -22,6 +22,7 @@ import androidx.appcompat.app.AppCompatActivity
 import com.bq.appupdateshelper_app.databinding.MainActivityBinding
 import com.bq.appupdateshelper_app.fake.FakeUpdateActivity
 import com.bq.appupdateshelper_app.flexible.FlexibleUpdateActivity
+import com.bq.appupdateshelper_app.fragment.FragmentUpdateActivity
 import com.bq.appupdateshelper_app.immediate.ImmediateUpdateActivity
 
 class MainActivity : AppCompatActivity() {
@@ -32,6 +33,9 @@ class MainActivity : AppCompatActivity() {
 
     private val flexibleButton: Button
         get() = binding.flexibleButton
+
+    private val fragmentButton: Button
+        get() = binding.fragmentButton
 
     private val fakeButton: Button
         get() = binding.fakeButton
@@ -48,6 +52,10 @@ class MainActivity : AppCompatActivity() {
 
         flexibleButton.setOnClickListener {
             startActivity(FlexibleUpdateActivity.newIntent(this))
+        }
+
+        fragmentButton.setOnClickListener {
+            startActivity(FragmentUpdateActivity.newIntent(this))
         }
 
         fakeButton.setOnClickListener {

--- a/app/src/main/kotlin/com/bq/appupdateshelper_app/MainActivity.kt
+++ b/app/src/main/kotlin/com/bq/appupdateshelper_app/MainActivity.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 BQ
+ * Copyright (C) 2020 BQ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,28 +14,33 @@
  * limitations under the License.
  */
 
-package com.bq.appupdateshelper
+package com.bq.appupdateshelper_app
 
 import android.os.Bundle
 import android.widget.Button
 import androidx.appcompat.app.AppCompatActivity
-import com.bq.appupdateshelper.fake.FakeUpdateActivity
-import com.bq.appupdateshelper.flexible.FlexibleUpdateActivity
-import com.bq.appupdateshelper.immediate.ImmediateUpdateActivity
+import com.bq.appupdateshelper_app.databinding.MainActivityBinding
+import com.bq.appupdateshelper_app.fake.FakeUpdateActivity
+import com.bq.appupdateshelper_app.flexible.FlexibleUpdateActivity
+import com.bq.appupdateshelper_app.immediate.ImmediateUpdateActivity
 
 class MainActivity : AppCompatActivity() {
+    private lateinit var binding: MainActivityBinding
+
     private val immediateButton: Button
-        get() = findViewById(R.id.immediate_button)
+        get() = binding.immediateButton
 
     private val flexibleButton: Button
-        get() = findViewById(R.id.flexible_button)
+        get() = binding.flexibleButton
 
     private val fakeButton: Button
-        get() = findViewById(R.id.fake_button)
+        get() = binding.fakeButton
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_main)
+        binding = MainActivityBinding.inflate(layoutInflater).apply {
+            setContentView(root)
+        }
 
         immediateButton.setOnClickListener {
             startActivity(ImmediateUpdateActivity.newIntent(this))

--- a/app/src/main/kotlin/com/bq/appupdateshelper_app/fake/FakeUpdateActivity.kt
+++ b/app/src/main/kotlin/com/bq/appupdateshelper_app/fake/FakeUpdateActivity.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.bq.appupdateshelper.fake
+package com.bq.appupdateshelper_app.fake
 
 import android.content.Context
 import android.content.Intent
@@ -26,8 +26,9 @@ import androidx.appcompat.app.AppCompatActivity
 import com.bq.appupdateshelper.AppUpdateInfoResult
 import com.bq.appupdateshelper.AppUpdateInstallState.Status.*
 import com.bq.appupdateshelper.FakeAppUpdatesHelper
-import com.bq.appupdateshelper.R
-import com.bq.appupdateshelper.misc.showToast
+import com.bq.appupdateshelper_app.databinding.FakeUpdateActivityBinding
+import com.bq.appupdateshelper_app.R
+import com.bq.appupdateshelper_app.misc.showToast
 import com.google.android.material.snackbar.Snackbar
 
 /**
@@ -48,12 +49,17 @@ class FakeUpdateActivity : AppCompatActivity() {
 
     private lateinit var fakeAppUpdatesHelper: FakeAppUpdatesHelper
 
+    private lateinit var binding: FakeUpdateActivityBinding
+
     private val startUpdateButton: Button
-        get() = findViewById(R.id.start_update_button)
+        get() = binding.startUpdateButton
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_fake_update)
+
+        binding = FakeUpdateActivityBinding.inflate(layoutInflater).apply {
+            setContentView(root)
+        }
 
         setTitle(R.string.activity_fake_update_title)
 
@@ -86,16 +92,16 @@ class FakeUpdateActivity : AppCompatActivity() {
                 DOWNLOADED -> {
                     showToast("The update has been downloaded!")
 
-                    Snackbar.make(findViewById(android.R.id.content), "Install the update?", Snackbar.LENGTH_INDEFINITE)
-                        .apply {
-                            setAction("Install") {
-                                fakeAppUpdatesHelper.completeUpdate()
+                    Snackbar.make(binding.root, "Install the update?", Snackbar.LENGTH_INDEFINITE)
+                            .apply {
+                                setAction("Install") {
+                                    fakeAppUpdatesHelper.completeUpdate()
 
-                                // Fake installation process
-                                fakeAppUpdatesHelper.completeFakeUpdate()
+                                    // Fake installation process
+                                    fakeAppUpdatesHelper.completeFakeUpdate()
+                                }
                             }
-                        }
-                        .show()
+                            .show()
                 }
                 INSTALLING -> {
                     showToast("The update is being installed!")
@@ -106,13 +112,13 @@ class FakeUpdateActivity : AppCompatActivity() {
                 FAILED -> {
                     showToast("The update failed! Reason: ${installState.errorCode}")
 
-                    Snackbar.make(findViewById(android.R.id.content), "Retry?", Snackbar.LENGTH_LONG)
-                        .apply {
-                            setAction("Retry") {
-                                fakeAppUpdatesHelper.startImmediateUpdate(this@FakeUpdateActivity)
+                    Snackbar.make(binding.root, "Retry?", Snackbar.LENGTH_LONG)
+                            .apply {
+                                setAction("Retry") {
+                                    fakeAppUpdatesHelper.startImmediateUpdate(this@FakeUpdateActivity)
+                                }
                             }
-                        }
-                        .show()
+                            .show()
                 }
                 CANCELED -> {
                     showToast("The user canceled the flexible update!")
@@ -161,7 +167,7 @@ class FakeUpdateActivity : AppCompatActivity() {
                     }
                 } else {
                     showToast("The update info could not be retrieved, " +
-                              "cause: ${appUpdateInfoResult.exception!!.message}")
+                            "cause: ${appUpdateInfoResult.exception!!.message}")
                 }
             }
         }

--- a/app/src/main/kotlin/com/bq/appupdateshelper_app/fake/FakeUpdateActivity.kt
+++ b/app/src/main/kotlin/com/bq/appupdateshelper_app/fake/FakeUpdateActivity.kt
@@ -90,7 +90,7 @@ class FakeUpdateActivity : AppCompatActivity() {
                     showToast("The update is downloading!")
                 }
                 DOWNLOADED -> {
-                    showToast("The update has been downloaded!")
+                    showToast("The update is downloading! Progress: ${installState.downloadProgress}")
 
                     Snackbar.make(binding.root, "Install the update?", Snackbar.LENGTH_INDEFINITE)
                             .apply {

--- a/app/src/main/kotlin/com/bq/appupdateshelper_app/flexible/FlexibleUpdateActivity.kt
+++ b/app/src/main/kotlin/com/bq/appupdateshelper_app/flexible/FlexibleUpdateActivity.kt
@@ -88,7 +88,7 @@ class FlexibleUpdateActivity : AppCompatActivity() {
                     showToast("Waiting for update to start!")
                 }
                 DOWNLOADING -> {
-                    showToast("The update is downloading!")
+                    showToast("The update is downloading! Progress: ${installState.downloadProgress}")
                 }
                 DOWNLOADED -> {
                     showToast("The update has been downloaded!")

--- a/app/src/main/kotlin/com/bq/appupdateshelper_app/flexible/FlexibleUpdateActivity.kt
+++ b/app/src/main/kotlin/com/bq/appupdateshelper_app/flexible/FlexibleUpdateActivity.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 BQ
+ * Copyright (C) 2020 BQ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.bq.appupdateshelper.flexible
+package com.bq.appupdateshelper_app.flexible
 
 import android.content.Context
 import android.content.Intent
@@ -25,8 +25,9 @@ import androidx.appcompat.app.AppCompatActivity
 import com.bq.appupdateshelper.AppUpdateInfoResult
 import com.bq.appupdateshelper.AppUpdateInstallState.Status.*
 import com.bq.appupdateshelper.AppUpdatesHelper
-import com.bq.appupdateshelper.R
-import com.bq.appupdateshelper.misc.showToast
+import com.bq.appupdateshelper_app.databinding.FlexibleUpdateActivityBinding
+import com.bq.appupdateshelper_app.R
+import com.bq.appupdateshelper_app.misc.showToast
 import com.google.android.material.snackbar.Snackbar
 
 /**
@@ -44,12 +45,16 @@ class FlexibleUpdateActivity : AppCompatActivity() {
 
     private lateinit var appUpdatesHelper: AppUpdatesHelper
 
+    private lateinit var binding: FlexibleUpdateActivityBinding
+
     private val startUpdateButton: Button
-        get() = findViewById(R.id.start_update_button)
+        get() = binding.startUpdateButton
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_flexible_update)
+        binding = FlexibleUpdateActivityBinding.inflate(layoutInflater).apply {
+            setContentView(root)
+        }
 
         setTitle(R.string.activity_flexible_update_title)
 
@@ -89,13 +94,13 @@ class FlexibleUpdateActivity : AppCompatActivity() {
                     showToast("The update has been downloaded!")
                     // Prompt the user to install the update when we know that the update has been
                     // downloaded successfully
-                    Snackbar.make(findViewById(android.R.id.content), "Install the update?", Snackbar.LENGTH_INDEFINITE)
-                        .apply {
-                            setAction("Install") {
-                                appUpdatesHelper.completeUpdate()
+                    Snackbar.make(binding.root, "Install the update?", Snackbar.LENGTH_INDEFINITE)
+                            .apply {
+                                setAction("Install") {
+                                    appUpdatesHelper.completeUpdate()
+                                }
                             }
-                        }
-                        .show()
+                            .show()
                 }
                 INSTALLING -> {
                     showToast("The update is being installed!")
@@ -111,13 +116,13 @@ class FlexibleUpdateActivity : AppCompatActivity() {
                     // process if needed
                     showToast("The update failed! Reason: ${installState.errorCode}")
 
-                    Snackbar.make(findViewById(android.R.id.content), "Retry?", Snackbar.LENGTH_LONG)
-                        .apply {
-                            setAction("Retry") {
-                                appUpdatesHelper.startFlexibleUpdate(this@FlexibleUpdateActivity)
+                    Snackbar.make(binding.root, "Retry?", Snackbar.LENGTH_LONG)
+                            .apply {
+                                setAction("Retry") {
+                                    appUpdatesHelper.startFlexibleUpdate(this@FlexibleUpdateActivity)
+                                }
                             }
-                        }
-                        .show()
+                            .show()
                 }
                 CANCELED -> {
                     // This state is only reachable in flexible updates and it happens when the
@@ -167,7 +172,7 @@ class FlexibleUpdateActivity : AppCompatActivity() {
                     }
                 } else {
                     showToast("The update info could not be retrieved, " +
-                              "cause: ${appUpdateInfoResult.exception!!.message}")
+                            "cause: ${appUpdateInfoResult.exception!!.message}")
                 }
             }
         }

--- a/app/src/main/kotlin/com/bq/appupdateshelper_app/fragment/FragmentUpdateActivity.kt
+++ b/app/src/main/kotlin/com/bq/appupdateshelper_app/fragment/FragmentUpdateActivity.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bq.appupdateshelper_app.fragment
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.bq.appupdateshelper.AppUpdatesHelper
+import com.bq.appupdateshelper_app.R
+import com.bq.appupdateshelper_app.databinding.FragmentUpdateActivityBinding
+
+/**
+ * Activity that illustrates the use of the [AppUpdatesHelper] class of the lib to start flexible
+ * updates in a fragment.
+ */
+class FragmentUpdateActivity : AppCompatActivity() {
+    companion object {
+        fun newIntent(context: Context): Intent {
+            return Intent(context, FragmentUpdateActivity::class.java)
+        }
+    }
+
+    private lateinit var binding: FragmentUpdateActivityBinding
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = FragmentUpdateActivityBinding.inflate(layoutInflater).apply {
+            setContentView(root)
+        }
+
+        setTitle(R.string.activity_fragment_update_title)
+    }
+}

--- a/app/src/main/kotlin/com/bq/appupdateshelper_app/fragment/FragmentUpdateFragment.kt
+++ b/app/src/main/kotlin/com/bq/appupdateshelper_app/fragment/FragmentUpdateFragment.kt
@@ -1,0 +1,200 @@
+/*
+ * Copyright (C) 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bq.appupdateshelper_app.fragment
+
+import android.content.Intent
+import android.os.Bundle
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import androidx.fragment.app.Fragment
+import com.bq.appupdateshelper.AppUpdateInfoResult
+import com.bq.appupdateshelper.AppUpdateInstallState
+import com.bq.appupdateshelper.AppUpdatesHelper
+import com.bq.appupdateshelper_app.databinding.FragmentUpdateFragmentBinding
+import com.bq.appupdateshelper_app.misc.showToast
+import com.google.android.material.snackbar.Snackbar
+
+/**
+ * Fragment that illustrates the use of the [AppUpdatesHelper] class of the lib to start flexible
+ * updates in a fragment.
+ */
+class FragmentUpdateFragment : Fragment() {
+    companion object {
+        private const val TAG = "FragmentUpdateFragment"
+
+        fun newInstance(): FragmentUpdateFragment {
+            val args = Bundle()
+
+            val fragment = FragmentUpdateFragment()
+            fragment.arguments = args
+            return fragment
+        }
+    }
+
+    private lateinit var appUpdatesHelper: AppUpdatesHelper
+
+    private lateinit var binding: FragmentUpdateFragmentBinding
+
+    private val startUpdateButton: Button
+        get() = binding.startUpdateButton
+
+    override fun onCreateView(inflater: LayoutInflater,
+                              container: ViewGroup?,
+                              savedInstanceState: Bundle?): View? =
+            FragmentUpdateFragmentBinding.inflate(inflater, container, false)
+                    .also { binding = it }.root
+
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        // Instantiate the app updates helper and start using it with startListening()
+        appUpdatesHelper = AppUpdatesHelper(requireContext())
+
+        appUpdatesHelper.startListening { installState ->
+            // The update process is tracked here from the moment the user clicks "Update" until the
+            // app is fully installed
+            Log.d(TAG, "Update install state: $installState")
+
+            when (installState.status) {
+                AppUpdateInstallState.Status.UNKNOWN -> {
+                    showToast("Unknown install state")
+                }
+                AppUpdateInstallState.Status.DENIED -> {
+                    // This should only be reached in immediate updates
+                    showToast("The user denied the flexible update!")
+                    requireActivity().finish()
+                }
+                AppUpdateInstallState.Status.REQUIRES_UI_INTENT -> {
+                    // The docs don't really say anything about this state or when it's triggered
+                    // so...
+                    showToast("The update needs an UI intent!")
+                }
+                AppUpdateInstallState.Status.UPDATE_ACCEPTED -> {
+                    // The user has accepted the update, so you can notify the user
+                    showToast("The user accepted the update!")
+                }
+                AppUpdateInstallState.Status.PENDING -> {
+                    showToast("Waiting for update to start!")
+                }
+                AppUpdateInstallState.Status.DOWNLOADING -> {
+                    showToast("The update is downloading! Progress: ${installState.downloadProgress}")
+                }
+                AppUpdateInstallState.Status.DOWNLOADED -> {
+                    showToast("The update has been downloaded!")
+                    // Prompt the user to install the update when we know that the update has been
+                    // downloaded successfully
+                    Snackbar.make(binding.root, "Install the update?", Snackbar.LENGTH_INDEFINITE)
+                            .apply {
+                                setAction("Install") {
+                                    appUpdatesHelper.completeUpdate()
+                                }
+                            }
+                            .show()
+                }
+                AppUpdateInstallState.Status.INSTALLING -> {
+                    showToast("The update is being installed!")
+                }
+                AppUpdateInstallState.Status.INSTALLED -> {
+                    // Usually you won't get up to this state, since the app closes automatically
+                    // in the installation process. Anyway, it's not a bad practice to consider this
+                    // case
+                    showToast("The update has been installed!")
+                }
+                AppUpdateInstallState.Status.FAILED -> {
+                    // The installation failed for some reason, here you can retry the update
+                    // process if needed
+                    showToast("The update failed! Reason: ${installState.errorCode}")
+
+                    Snackbar.make(binding.root, "Retry?", Snackbar.LENGTH_LONG)
+                            .apply {
+                                setAction("Retry") {
+                                    appUpdatesHelper.startFlexibleUpdate(this@FragmentUpdateFragment)
+                                }
+                            }
+                            .show()
+                }
+                AppUpdateInstallState.Status.CANCELED -> {
+                    // This state is only reachable in flexible updates and it happens when the
+                    // user cancels a flexible update. There's no need to do anything in this case.
+                    showToast("The user canceled the flexible update!")
+                }
+            }
+        }
+
+        startUpdateButton.setOnClickListener {
+            // Start the update flow by first checking if there's any update available for the app
+            // in the Play Store using getAppUpdateInfo()
+            appUpdatesHelper.getAppUpdateInfo { appUpdateInfoResult ->
+                Log.d(TAG, "App update info: $appUpdateInfoResult")
+
+                if (appUpdateInfoResult.isSuccessful) {
+                    // If the request went well, you can check the state of the app update
+                    when (appUpdateInfoResult.updateAvailability!!) {
+                        AppUpdateInfoResult.Availability.UNKNOWN -> {
+                            showToast("The state of the update is unknown!")
+                        }
+                        AppUpdateInfoResult.Availability.UPDATE_NOT_AVAILABLE -> {
+                            showToast("No update available!")
+                        }
+                        AppUpdateInfoResult.Availability.UPDATE_AVAILABLE -> {
+                            showToast("Update available!")
+                            // When we know that the update is available, we must check if we can
+                            // perform the desired type of update
+                            if (appUpdateInfoResult.canInstallFlexibleUpdate()) {
+                                // Start the update flow
+                                showToast("Can install flexible update!")
+                                appUpdatesHelper.startFlexibleUpdate(this)
+                            } else {
+                                showToast("Can not install flexible update!")
+                            }
+                        }
+                        AppUpdateInfoResult.Availability.UPDATE_IN_PROGRESS -> {
+                            // If the update is in progress, we don't need to jump to the flexible flow again
+                            showToast("Update in progress!")
+                        }
+                        AppUpdateInfoResult.Availability.UPDATE_DOWNLOADED -> {
+                            // The app update is downloaded, but the install flow has not started
+                            // yet, so complete the update
+                            showToast("Update downloaded!")
+                            appUpdatesHelper.completeUpdate()
+                        }
+                    }
+                } else {
+                    showToast("The update info could not be retrieved, " +
+                            "cause: ${appUpdateInfoResult.exception!!.message}")
+                }
+            }
+        }
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+
+        // We have to bind the helper to the activity results so it can properly dispatch some
+        // update events
+        appUpdatesHelper.onUpdateStatusResult(requestCode, resultCode)
+    }
+
+    override fun onDestroyView() {
+        // Stop listening for updates with stopListening()
+        super.onDestroyView()
+        appUpdatesHelper.stopListening()
+    }
+}

--- a/app/src/main/kotlin/com/bq/appupdateshelper_app/immediate/ImmediateUpdateActivity.kt
+++ b/app/src/main/kotlin/com/bq/appupdateshelper_app/immediate/ImmediateUpdateActivity.kt
@@ -90,7 +90,7 @@ class ImmediateUpdateActivity : AppCompatActivity() {
                     showToast("Waiting for update to start!")
                 }
                 DOWNLOADING -> {
-                    showToast("The update is downloading!")
+                    showToast("The update is downloading! Progress: ${installState.downloadProgress}")
                 }
                 DOWNLOADED -> {
                     showToast("The update has been downloaded!")

--- a/app/src/main/kotlin/com/bq/appupdateshelper_app/immediate/ImmediateUpdateActivity.kt
+++ b/app/src/main/kotlin/com/bq/appupdateshelper_app/immediate/ImmediateUpdateActivity.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 BQ
+ * Copyright (C) 2020 BQ
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.bq.appupdateshelper.immediate
+package com.bq.appupdateshelper_app.immediate
 
 import android.content.Context
 import android.content.Intent
@@ -25,8 +25,9 @@ import androidx.appcompat.app.AppCompatActivity
 import com.bq.appupdateshelper.AppUpdateInfoResult
 import com.bq.appupdateshelper.AppUpdateInstallState.Status.*
 import com.bq.appupdateshelper.AppUpdatesHelper
-import com.bq.appupdateshelper.R
-import com.bq.appupdateshelper.misc.showToast
+import com.bq.appupdateshelper_app.databinding.ImmediateUpdateActivityBinding
+import com.bq.appupdateshelper_app.R
+import com.bq.appupdateshelper_app.misc.showToast
 import com.google.android.material.snackbar.Snackbar
 
 /**
@@ -44,12 +45,16 @@ class ImmediateUpdateActivity : AppCompatActivity() {
 
     private lateinit var appUpdatesHelper: AppUpdatesHelper
 
+    private lateinit var binding: ImmediateUpdateActivityBinding
+
     private val startUpdateButton: Button
-        get() = findViewById(R.id.start_update_button)
+        get() = binding.startUpdateButton
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_immediate_update)
+        binding = ImmediateUpdateActivityBinding.inflate(layoutInflater).apply {
+            setContentView(root)
+        }
 
         setTitle(R.string.activity_immediate_update_title)
 
@@ -104,13 +109,13 @@ class ImmediateUpdateActivity : AppCompatActivity() {
                     // process if needed
                     showToast("The update failed! Reason: ${installState.errorCode}")
 
-                    Snackbar.make(findViewById(android.R.id.content), "Retry?", Snackbar.LENGTH_LONG)
-                        .apply {
-                            setAction("Retry") {
-                                appUpdatesHelper.startImmediateUpdate(this@ImmediateUpdateActivity)
+                    Snackbar.make(binding.root, "Retry?", Snackbar.LENGTH_LONG)
+                            .apply {
+                                setAction("Retry") {
+                                    appUpdatesHelper.startImmediateUpdate(this@ImmediateUpdateActivity)
+                                }
                             }
-                        }
-                        .show()
+                            .show()
                 }
                 CANCELED -> {
                     // This state is only reachable in flexible updates.
@@ -160,7 +165,7 @@ class ImmediateUpdateActivity : AppCompatActivity() {
                     }
                 } else {
                     showToast("The update info could not be retrieved, " +
-                              "cause: ${appUpdateInfoResult.exception!!.message}")
+                            "cause: ${appUpdateInfoResult.exception!!.message}")
                 }
             }
         }

--- a/app/src/main/kotlin/com/bq/appupdateshelper_app/misc/ActivityExtensions.kt
+++ b/app/src/main/kotlin/com/bq/appupdateshelper_app/misc/ActivityExtensions.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.bq.appupdateshelper.misc
+package com.bq.appupdateshelper_app.misc
 
 import android.app.Activity
 import android.widget.Toast

--- a/app/src/main/kotlin/com/bq/appupdateshelper_app/misc/FragmentExtensions.kt
+++ b/app/src/main/kotlin/com/bq/appupdateshelper_app/misc/FragmentExtensions.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bq.appupdateshelper_app.misc
+
+import android.widget.Toast
+import androidx.annotation.StringRes
+import androidx.fragment.app.Fragment
+
+/**
+ * Displays a text as a toast in the current fragment.
+ *
+ * @param text Text to display in the toast
+ * @param duration Duration, one of [Toast.LENGTH_SHORT] or [Toast.LENGTH_LONG]
+ */
+fun Fragment.showToast(text: String, duration: Int = Toast.LENGTH_SHORT) {
+    Toast.makeText(context, text, duration).show()
+}
+
+/**
+ * Displays a text as a toast in the current fragment.
+ *
+ * @param stringResId Text to display in the toast as a string resource ID
+ * @param duration Duration, one of [Toast.LENGTH_SHORT] or [Toast.LENGTH_LONG]
+ */
+fun Fragment.showToast(@StringRes stringResId: Int, duration: Int = Toast.LENGTH_SHORT) {
+    Toast.makeText(context, stringResId, duration).show()
+}

--- a/app/src/main/res/layout/fake_update_activity.xml
+++ b/app/src/main/res/layout/fake_update_activity.xml
@@ -21,14 +21,14 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_height="match_parent"
     android:layout_width="match_parent"
-    tools:context="com.bq.appupdateshelper.flexible.FlexibleUpdateActivity"
+    tools:context="com.bq.appupdateshelper_app.fake.FakeUpdateActivity"
     tools:ignore="HardcodedText">
 
     <TextView
         android:id="@+id/text_view_1"
         android:layout_height="wrap_content"
         android:layout_width="wrap_content"
-        android:text="Flexible updates example"
+        android:text="Fake updates example"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"/>
 
@@ -37,7 +37,7 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
         android:layout_width="wrap_content"
-        android:text="This example illustrates how flexible updates work in an usual app flow.\n\nClick the button to start the flexible updates flow"
+        android:text="This example illustrates how fake updates work in an usual app flow.\n\nClick the button to start the fake updates flow"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/text_view_1"/>
 
@@ -46,7 +46,7 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp"
         android:layout_width="wrap_content"
-        android:text="Start flexible update"
+        android:text="Start fake update"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/text_view_2"/>

--- a/app/src/main/res/layout/flexible_update_activity.xml
+++ b/app/src/main/res/layout/flexible_update_activity.xml
@@ -21,14 +21,14 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_height="match_parent"
     android:layout_width="match_parent"
-    tools:context="com.bq.appupdateshelper.fake.FakeUpdateActivity"
+    tools:context="com.bq.appupdateshelper_app.flexible.FlexibleUpdateActivity"
     tools:ignore="HardcodedText">
 
     <TextView
         android:id="@+id/text_view_1"
         android:layout_height="wrap_content"
         android:layout_width="wrap_content"
-        android:text="Fake updates example"
+        android:text="Flexible updates example"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"/>
 
@@ -37,7 +37,7 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
         android:layout_width="wrap_content"
-        android:text="This example illustrates how fake updates work in an usual app flow.\n\nClick the button to start the fake updates flow"
+        android:text="This example illustrates how flexible updates work in an usual app flow.\n\nClick the button to start the flexible updates flow"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/text_view_1"/>
 
@@ -46,7 +46,7 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp"
         android:layout_width="wrap_content"
-        android:text="Start fake update"
+        android:text="Start flexible update"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/text_view_2"/>

--- a/app/src/main/res/layout/fragment_update_activity.xml
+++ b/app/src/main/res/layout/fragment_update_activity.xml
@@ -1,5 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright (C) 2019 BQ
+  ~ Copyright (C) 2020 BQ
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -14,12 +15,14 @@
   ~ limitations under the License.
   -->
 
-<resources>
-    <string name="app_name">App Updates Helper</string>
-    <string name="activity_main_title">App Updates Helper</string>
-    <string name="activity_flexible_update_title">Flexible updates example</string>
-    <string name="activity_immediate_update_title">Immediate updates example</string>
-    <string name="activity_fake_update_title">Fake updates example</string>
-    <string name="activity_fragment_update_title">In-app updates in Fragments</string>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
 
-</resources>
+    <fragment
+        android:id="@+id/fragment_update_fragment"
+        android:name="com.bq.appupdateshelper_app.fragment.FragmentUpdateFragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_update_fragment.xml
+++ b/app/src/main/res/layout/fragment_update_fragment.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2019 BQ
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_height="match_parent"
+    android:layout_width="match_parent"
+    tools:context="com.bq.appupdateshelper_app.fragment.FragmentUpdateActivity"
+    tools:ignore="HardcodedText">
+
+    <TextView
+        android:id="@+id/text_view_1"
+        android:layout_height="wrap_content"
+        android:layout_width="wrap_content"
+        android:text="Fragment updates example"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"/>
+
+    <TextView
+        android:id="@+id/text_view_2"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:layout_width="wrap_content"
+        android:text="This example illustrates how you can also perform updates in a fragment instead of an activity.\n\nClick the button to start the flexible updates flow"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/text_view_1"/>
+
+    <Button
+        android:id="@+id/start_update_button"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:layout_width="wrap_content"
+        android:text="Start flexible update in fragment"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/text_view_2"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/immediate_update_activity.xml
+++ b/app/src/main/res/layout/immediate_update_activity.xml
@@ -22,7 +22,7 @@
     android:layout_height="match_parent"
     android:layout_margin="8dp"
     android:layout_width="match_parent"
-    tools:context="com.bq.appupdateshelper.immediate.ImmediateUpdateActivity"
+    tools:context="com.bq.appupdateshelper_app.immediate.ImmediateUpdateActivity"
     tools:ignore="HardcodedText">
 
     <TextView

--- a/app/src/main/res/layout/main_activity.xml
+++ b/app/src/main/res/layout/main_activity.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright (C) 2019 BQ
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,43 +14,52 @@
   ~ limitations under the License.
   -->
 
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_height="match_parent"
     android:layout_width="match_parent"
+    android:layout_height="match_parent"
     tools:context="com.bq.appupdateshelper_app.MainActivity"
     tools:ignore="HardcodedText">
 
     <Button
         android:id="@+id/immediate_button"
-        android:layout_height="wrap_content"
         android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         android:text="Immediate update"
         app:layout_constraintBottom_toTopOf="@+id/flexible_button"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_chainStyle="packed"/>
+        app:layout_constraintVertical_chainStyle="packed" />
 
     <Button
         android:id="@+id/flexible_button"
-        android:layout_height="wrap_content"
         android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         android:text="Flexible update"
+        app:layout_constraintBottom_toTopOf="@+id/fragment_button"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/immediate_button" />
+
+    <Button
+        android:id="@+id/fragment_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Fragment update"
         app:layout_constraintBottom_toTopOf="@+id/fake_button"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/immediate_button"/>
+        app:layout_constraintTop_toBottomOf="@+id/flexible_button" />
 
     <Button
         android:id="@+id/fake_button"
-        android:layout_height="wrap_content"
         android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         android:text="Fake update"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/flexible_button"/>
+        app:layout_constraintTop_toBottomOf="@+id/fragment_button" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/main_activity.xml
+++ b/app/src/main/res/layout/main_activity.xml
@@ -21,7 +21,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_height="match_parent"
     android:layout_width="match_parent"
-    tools:context=".MainActivity"
+    tools:context="com.bq.appupdateshelper_app.MainActivity"
     tools:ignore="HardcodedText">
 
     <Button

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath "com.android.tools.build:gradle:4.1.0"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "com.github.dcendents:android-maven-gradle-plugin:2.1"
         classpath "com.gladed.androidgitversion:gradle-android-git-version:0.4.13"

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.2'
+        classpath 'com.android.tools.build:gradle:4.1.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "com.github.dcendents:android-maven-gradle-plugin:2.1"
         classpath "com.gladed.androidgitversion:gradle-android-git-version:0.4.13"

--- a/build.gradle
+++ b/build.gradle
@@ -17,17 +17,17 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlinVersion = '1.4.10'
+    ext.kotlin_version = "1.4.10"
 
     repositories {
         google()
         jcenter()
         mavenCentral()
-        maven {url "https://plugins.gradle.org/m2/"}
+        maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.1'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
+        classpath 'com.android.tools.build:gradle:4.0.2'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "com.github.dcendents:android-maven-gradle-plugin:2.1"
         classpath "com.gladed.androidgitversion:gradle-android-git-version:0.4.13"
     }
@@ -40,9 +40,7 @@ allprojects {
     }
 
     ext {
-        compileSdkVersion = 29
-        minSdkVersion = 21
-        targetSdkVersion = 29
+        kotlin_version = "1.4.10"
     }
 }
 

--- a/gradle/properties_utils.gradle
+++ b/gradle/properties_utils.gradle
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2020 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Utility method that loads a Properties object from a given file name.
+ *
+ * @param fileName name of the properties file
+ * @return a Properties object, empty if the file could not be loaded
+ */
+def loadPropertiesFile(fileName) {
+    try {
+        Properties properties = new Properties()
+        properties.load(new FileInputStream(rootProject.file(fileName)))
+
+        return properties
+    }
+    catch (ignored) {
+        logger.info("File \"$fileName\" not found, returning empty properties object")
+        return new Properties()
+    }
+}
+
+/**
+ * Utility method that tries to find a variable in the following places:
+ * - System environment variable
+ * - Property in a properties file (the property will try to find the name in camel case)
+ *
+ * System environment property takes precedence over the property in a properties file.
+ *
+ * @param key Key to find in snake case
+ * @param defaultValue Default value in case the key is not found, null by default
+ * @param propertiesFileName file in the root of the project to check for properties. If not defined,
+ *                           it will default to the project's gradle.properties
+ */
+def loadEnvOrProperty(String key, defaultValue = null, String propertiesFileName = "gradle.properties") {
+    def envVarKey = key
+    def propertyKey = toCamelCase(key)
+
+    logger.info("Trying to find environment variable \"$envVarKey\" (or $propertiesFileName property \"$propertyKey\")")
+
+    // First try to get the value from the environment variable
+    def result = System.getenv(envVarKey)
+
+    if (result == null) {
+        logger.info("Environment variable \"$envVarKey\" not found, trying to find it in $propertiesFileName property \"$propertyKey\"")
+
+        // Then try to get it from the properties file
+        def properties = loadPropertiesFile(propertiesFileName)
+
+        if (properties == null) {
+            // If none could be found, return the default value
+            logger.error("Requested file $propertiesFileName not found, returning default value")
+            return defaultValue
+        }
+
+        result = properties[propertyKey]
+    }
+
+    if (result == null) {
+        logger.error("Environment variable \"$envVarKey\" (or $propertiesFileName property \"$propertyKey\") not found, returning default value")
+        return defaultValue
+    }
+    else {
+        return result
+    }
+}
+
+static String toCamelCase(String text, boolean capitalized = false) {
+    def newText = text.toLowerCase().replaceAll("(_)([A-Za-z0-9])", { Object[] it -> it[2].toUpperCase() })
+    return capitalized ? capitalize(newText) : newText
+}
+
+ext {
+    loadPropertiesFile = this.&loadPropertiesFile
+    loadEnvOrProperty = this.&loadEnvOrProperty
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Sep 24 17:32:09 CEST 2020
+#Tue Oct 13 10:26:28 CEST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2019 BQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 apply plugin: 'com.android.library'
 apply plugin: "com.gladed.androidgitversion"
 
@@ -7,12 +23,25 @@ androidGitVersion {
     tagPattern(/^[0-9]+.*/) // Tag names should follow the pattern MM.NN.PP
 }
 
+ext {
+    /*
+     ********************
+     * Android variables
+     ********************
+     */
+    compile_sdk_version = 30
+    min_sdk_version = 21
+    target_sdk_version = 30
+    build_tools_version = "30.0.2"
+}
+
 android {
-    compileSdkVersion 30
+    compileSdkVersion compile_sdk_version
+    buildToolsVersion = build_tools_version
 
     defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 30
+        minSdkVersion min_sdk_version
+        targetSdkVersion target_sdk_version
         versionName androidGitVersion.name()
         versionCode androidGitVersion.code()
 
@@ -35,29 +64,13 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.2.0'
 
     // Needed for the in-app updates API
-    api "com.google.android.play:core:1.8.0"
+    api "com.google.android.play:core:1.8.2"
 
     testImplementation 'junit:junit:4.13'
 
     androidTestImplementation 'androidx.test:runner:1.3.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
 }
-
-/*
- * Copyright (C) 2019 BQ
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 
 // Build a jar with source files
 task sourcesJar(type: Jar) {

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -55,6 +55,10 @@ android {
         }
     }
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 dependencies {

--- a/lib/src/main/java/com/bq/appupdateshelper/AppUpdateInfoResult.java
+++ b/lib/src/main/java/com/bq/appupdateshelper/AppUpdateInfoResult.java
@@ -35,10 +35,13 @@ import static com.google.android.play.core.install.model.InstallStatus.DOWNLOADE
 public class AppUpdateInfoResult {
     public static final int VERSION_UNKNOWN = -1;
     public static final int VERSION_STALENESS_UNKNOWN = -1;
+    public static final int UPDATE_PRIORITY_UNKNOWN = -1;
+
 
     private final boolean isSuccessful;
     private final int versionCode;
     private final Availability updateAvailability;
+    private final int updatePriority;
     private final boolean canInstallFlexibleUpdate;
     private final boolean canInstallImmediateUpdate;
     private final int clientVersionStalenessDays;
@@ -49,8 +52,9 @@ public class AppUpdateInfoResult {
         this.isSuccessful = info != null && exception == null;
         this.versionCode = (info != null) ? info.availableVersionCode() : VERSION_UNKNOWN;
         this.updateAvailability = Availability.from(
-            (info != null) ? info.updateAvailability() : UpdateAvailability.UNKNOWN,
-            (info != null) ? info.installStatus() : InstallStatus.UNKNOWN);
+                (info != null) ? info.updateAvailability() : UpdateAvailability.UNKNOWN,
+                (info != null) ? info.installStatus() : InstallStatus.UNKNOWN);
+        this.updatePriority = info != null ? info.updatePriority() : UPDATE_PRIORITY_UNKNOWN;
         this.canInstallFlexibleUpdate = info != null && info.isUpdateTypeAllowed(AppUpdateType.FLEXIBLE);
         this.canInstallImmediateUpdate = info != null && info.isUpdateTypeAllowed(AppUpdateType.IMMEDIATE);
 
@@ -62,16 +66,20 @@ public class AppUpdateInfoResult {
         this.exception = exception;
     }
 
-    @VisibleForTesting AppUpdateInfoResult(boolean isSuccessful,
-                                           int versionCode,
-                                           Availability updateAvailability,
-                                           boolean canInstallFlexibleUpdate,
-                                           boolean canInstallImmediateUpdate,
-                                           int clientVersionStalenessDays,
-                                           Exception exception) {
+    @VisibleForTesting
+    @SuppressWarnings("checkstyle:ParameterNumber")
+    AppUpdateInfoResult(boolean isSuccessful,
+                        int versionCode,
+                        Availability updateAvailability,
+                        int updatePriority,
+                        boolean canInstallFlexibleUpdate,
+                        boolean canInstallImmediateUpdate,
+                        int clientVersionStalenessDays,
+                        Exception exception) {
         this.isSuccessful = isSuccessful;
         this.versionCode = versionCode;
         this.updateAvailability = updateAvailability;
+        this.updatePriority = updatePriority;
         this.canInstallFlexibleUpdate = canInstallFlexibleUpdate;
         this.canInstallImmediateUpdate = canInstallImmediateUpdate;
         this.clientVersionStalenessDays = clientVersionStalenessDays;
@@ -88,6 +96,10 @@ public class AppUpdateInfoResult {
 
     public Availability getUpdateAvailability() {
         return updateAvailability;
+    }
+
+    public int getUpdatePriority() {
+        return updatePriority;
     }
 
     public int getClientVersionStalenessDays() {
@@ -120,6 +132,7 @@ public class AppUpdateInfoResult {
         AppUpdateInfoResult that = (AppUpdateInfoResult) o;
         return isSuccessful == that.isSuccessful &&
                 versionCode == that.versionCode &&
+                updatePriority == that.updatePriority &&
                 canInstallFlexibleUpdate == that.canInstallFlexibleUpdate &&
                 canInstallImmediateUpdate == that.canInstallImmediateUpdate &&
                 clientVersionStalenessDays == that.clientVersionStalenessDays &&
@@ -127,12 +140,11 @@ public class AppUpdateInfoResult {
                 exception.equals(that.exception);
     }
 
-
     @Override
     public int hashCode() {
-        return Objects.hash(
-                isSuccessful, versionCode, updateAvailability, canInstallFlexibleUpdate,
-                canInstallImmediateUpdate, clientVersionStalenessDays, exception);
+        return Objects.hash(isSuccessful, versionCode, updateAvailability,
+                updatePriority, canInstallFlexibleUpdate, canInstallImmediateUpdate,
+                clientVersionStalenessDays, exception);
     }
 
     @Override
@@ -141,6 +153,7 @@ public class AppUpdateInfoResult {
                 "isSuccessful=" + isSuccessful +
                 ", versionCode=" + versionCode +
                 ", updateAvailability=" + updateAvailability +
+                ", updatePriority=" + updatePriority +
                 ", canInstallFlexibleUpdate=" + canInstallFlexibleUpdate +
                 ", canInstallImmediateUpdate=" + canInstallImmediateUpdate +
                 ", clientVersionStalenessDays=" + clientVersionStalenessDays +

--- a/lib/src/main/java/com/bq/appupdateshelper/AppUpdateInfoResult.java
+++ b/lib/src/main/java/com/bq/appupdateshelper/AppUpdateInfoResult.java
@@ -33,22 +33,31 @@ import static com.google.android.play.core.install.model.InstallStatus.DOWNLOADE
  * {@link AppUpdatesHelper#getAppUpdateInfo(GetUpdateInfoListener)}.
  */
 public class AppUpdateInfoResult {
+    public static final int VERSION_UNKNOWN = -1;
+    public static final int VERSION_STALENESS_UNKNOWN = -1;
+
     private final boolean isSuccessful;
     private final int versionCode;
     private final Availability updateAvailability;
     private final boolean canInstallFlexibleUpdate;
     private final boolean canInstallImmediateUpdate;
+    private final int clientVersionStalenessDays;
     private final Exception exception;
 
     AppUpdateInfoResult(@Nullable AppUpdateInfo info,
                         @Nullable Exception exception) {
         this.isSuccessful = info != null && exception == null;
-        this.versionCode = (info != null) ? info.availableVersionCode() : -1;
+        this.versionCode = (info != null) ? info.availableVersionCode() : VERSION_UNKNOWN;
         this.updateAvailability = Availability.from(
-            (info != null) ? info.updateAvailability() : -1,
-            (info != null) ? info.installStatus() : -1);
+            (info != null) ? info.updateAvailability() : UpdateAvailability.UNKNOWN,
+            (info != null) ? info.installStatus() : InstallStatus.UNKNOWN);
         this.canInstallFlexibleUpdate = info != null && info.isUpdateTypeAllowed(AppUpdateType.FLEXIBLE);
         this.canInstallImmediateUpdate = info != null && info.isUpdateTypeAllowed(AppUpdateType.IMMEDIATE);
+
+        Integer infoVersionStalenessDays =
+                info != null ? info.clientVersionStalenessDays() : Integer.valueOf(VERSION_STALENESS_UNKNOWN);
+        //noinspection ConstantConditions
+        this.clientVersionStalenessDays = infoVersionStalenessDays != null ? infoVersionStalenessDays : VERSION_STALENESS_UNKNOWN;
 
         this.exception = exception;
     }
@@ -57,12 +66,15 @@ public class AppUpdateInfoResult {
                                            int versionCode,
                                            Availability updateAvailability,
                                            boolean canInstallFlexibleUpdate,
-                                           boolean canInstallImmediateUpdate, Exception exception) {
+                                           boolean canInstallImmediateUpdate,
+                                           int clientVersionStalenessDays,
+                                           Exception exception) {
         this.isSuccessful = isSuccessful;
         this.versionCode = versionCode;
         this.updateAvailability = updateAvailability;
         this.canInstallFlexibleUpdate = canInstallFlexibleUpdate;
         this.canInstallImmediateUpdate = canInstallImmediateUpdate;
+        this.clientVersionStalenessDays = clientVersionStalenessDays;
         this.exception = exception;
     }
 
@@ -76,6 +88,10 @@ public class AppUpdateInfoResult {
 
     public Availability getUpdateAvailability() {
         return updateAvailability;
+    }
+
+    public int getClientVersionStalenessDays() {
+        return clientVersionStalenessDays;
     }
 
     /**
@@ -103,27 +119,33 @@ public class AppUpdateInfoResult {
         if (o == null || getClass() != o.getClass()) return false;
         AppUpdateInfoResult that = (AppUpdateInfoResult) o;
         return isSuccessful == that.isSuccessful &&
-            versionCode == that.versionCode &&
-            canInstallFlexibleUpdate == that.canInstallFlexibleUpdate &&
-            canInstallImmediateUpdate == that.canInstallImmediateUpdate &&
-            updateAvailability == that.updateAvailability &&
-            Objects.equals(exception, that.exception);
+                versionCode == that.versionCode &&
+                canInstallFlexibleUpdate == that.canInstallFlexibleUpdate &&
+                canInstallImmediateUpdate == that.canInstallImmediateUpdate &&
+                clientVersionStalenessDays == that.clientVersionStalenessDays &&
+                updateAvailability == that.updateAvailability &&
+                exception.equals(that.exception);
     }
+
 
     @Override
     public int hashCode() {
-        return Objects.hash(isSuccessful, versionCode, updateAvailability, canInstallFlexibleUpdate, canInstallImmediateUpdate, exception);
+        return Objects.hash(
+                isSuccessful, versionCode, updateAvailability, canInstallFlexibleUpdate,
+                canInstallImmediateUpdate, clientVersionStalenessDays, exception);
     }
 
-    @Override public String toString() {
+    @Override
+    public String toString() {
         return "AppUpdateInfoResult{" +
-            "isSuccessful=" + isSuccessful +
-            ", versionCode=" + versionCode +
-            ", updateAvailability=" + updateAvailability +
-            ", canInstallFlexibleUpdate=" + canInstallFlexibleUpdate +
-            ", canInstallImmediateUpdate=" + canInstallImmediateUpdate +
-            ", exception=" + exception +
-            '}';
+                "isSuccessful=" + isSuccessful +
+                ", versionCode=" + versionCode +
+                ", updateAvailability=" + updateAvailability +
+                ", canInstallFlexibleUpdate=" + canInstallFlexibleUpdate +
+                ", canInstallImmediateUpdate=" + canInstallImmediateUpdate +
+                ", clientVersionStalenessDays=" + clientVersionStalenessDays +
+                ", exception=" + exception +
+                '}';
     }
 
     /**

--- a/lib/src/main/java/com/bq/appupdateshelper/AppUpdateInstallState.java
+++ b/lib/src/main/java/com/bq/appupdateshelper/AppUpdateInstallState.java
@@ -173,37 +173,37 @@ public class AppUpdateInstallState {
 
     /**
      * Specific enum related to an app install error code. It will always be present in {@link AppUpdateInstallState}
-     * (even in non-error cases, then the value of this field will be NO_ERROR or NO_ERROR_PARTIALLY_ALLOWED)
+     * (even in non-error cases, then the value of this field will be NO_ERROR)
      * <p>
      * The enums represent the following states:
      * <p>
      * - NO_ERROR: No error occurred; all types of update flow are allowed.
-     * - NO_ERROR_PARTIALLY_ALLOWED: No error occurred; only some types of update flow are allowed, while others are forbidden.
      * - ERROR_UNKNOWN: An unknown error occurred.
-     * - ERROR_API_NOT_AVAILABLE: The API is not available on this device.
+     * - ERROR_API_NOT_AVAILABLE: The API is not available on this device (such as when the device is not supported).
      * - ERROR_INVALID_REQUEST: The request that was sent by the app is malformed.
      * - ERROR_INSTALL_UNAVAILABLE: The install is unavailable to this user or device.
      * - ERROR_INSTALL_NOT_ALLOWED: The download/install is not allowed, due to the current device state (e.g. low battery, low disk space…)
      * - ERROR_DOWNLOAD_NOT_PRESENT: The install/update has not been (fully) downloaded yet.
+     * - ERROR_APP_NOT_OWNED: The user hasn't acquired the app via Play
+     * - ERROR_PLAY_STORE_NOT_FOUND: The Play Store app is either not installed or not the official version.
      * - ERROR_INTERNAL_ERROR: An internal error happened in the Play Store.
      */
     public enum ErrorCode {
         NO_ERROR,
-        NO_ERROR_PARTIALLY_ALLOWED,
         ERROR_UNKNOWN,
         ERROR_API_NOT_AVAILABLE,
         ERROR_INVALID_REQUEST,
         ERROR_INSTALL_UNAVAILABLE,
         ERROR_INSTALL_NOT_ALLOWED,
         ERROR_DOWNLOAD_NOT_PRESENT,
+        ERROR_APP_NOT_OWNED,
+        ERROR_PLAY_STORE_NOT_FOUND,
         ERROR_INTERNAL_ERROR;
 
         static ErrorCode from(InstallState state) {
             switch (state.installErrorCode()) {
                 case InstallErrorCode.NO_ERROR:
                     return ErrorCode.NO_ERROR;
-                case InstallErrorCode.NO_ERROR_PARTIALLY_ALLOWED:
-                    return ErrorCode.NO_ERROR_PARTIALLY_ALLOWED;
                 case InstallErrorCode.ERROR_API_NOT_AVAILABLE:
                     return ErrorCode.ERROR_API_NOT_AVAILABLE;
                 case InstallErrorCode.ERROR_INVALID_REQUEST:
@@ -214,9 +214,15 @@ public class AppUpdateInstallState {
                     return ErrorCode.ERROR_INSTALL_NOT_ALLOWED;
                 case InstallErrorCode.ERROR_DOWNLOAD_NOT_PRESENT:
                     return ErrorCode.ERROR_DOWNLOAD_NOT_PRESENT;
+                case InstallErrorCode.ERROR_APP_NOT_OWNED:
+                    return ErrorCode.ERROR_APP_NOT_OWNED;
+                case InstallErrorCode.ERROR_PLAY_STORE_NOT_FOUND:
+                    return ErrorCode.ERROR_PLAY_STORE_NOT_FOUND;
                 case InstallErrorCode.ERROR_INTERNAL_ERROR:
                     return ErrorCode.ERROR_INTERNAL_ERROR;
                 case InstallErrorCode.ERROR_UNKNOWN:
+                    //noinspection deprecation
+                case InstallErrorCode.NO_ERROR_PARTIALLY_ALLOWED:
                 default:
                     return ErrorCode.ERROR_UNKNOWN;
             }
@@ -227,8 +233,6 @@ public class AppUpdateInstallState {
             switch (this) {
                 case NO_ERROR:
                     return InstallErrorCode.NO_ERROR;
-                case NO_ERROR_PARTIALLY_ALLOWED:
-                    return InstallErrorCode.NO_ERROR_PARTIALLY_ALLOWED;
                 case ERROR_API_NOT_AVAILABLE:
                     return InstallErrorCode.ERROR_API_NOT_AVAILABLE;
                 case ERROR_INVALID_REQUEST:
@@ -239,6 +243,10 @@ public class AppUpdateInstallState {
                     return InstallErrorCode.ERROR_INSTALL_NOT_ALLOWED;
                 case ERROR_DOWNLOAD_NOT_PRESENT:
                     return InstallErrorCode.ERROR_DOWNLOAD_NOT_PRESENT;
+                case ERROR_APP_NOT_OWNED:
+                    return InstallErrorCode.ERROR_APP_NOT_OWNED;
+                case ERROR_PLAY_STORE_NOT_FOUND:
+                    return InstallErrorCode.ERROR_PLAY_STORE_NOT_FOUND;
                 case ERROR_INTERNAL_ERROR:
                     return InstallErrorCode.ERROR_INTERNAL_ERROR;
                 case ERROR_UNKNOWN:

--- a/lib/src/main/java/com/bq/appupdateshelper/AppUpdatesHelper.java
+++ b/lib/src/main/java/com/bq/appupdateshelper/AppUpdatesHelper.java
@@ -290,15 +290,10 @@ public class AppUpdatesHelper {
                     );
                     break;
                 default:
-                    // If everything goes well, check which updates are allowed and use the proper (no) error code
-                    boolean areAllUpdateFlowsAllowed = appUpdateInfo.isUpdateTypeAllowed(AppUpdateType.IMMEDIATE)
-                            && appUpdateInfo.isUpdateTypeAllowed(AppUpdateType.FLEXIBLE);
-
+                    // If everything goes well, do stuff
                     state = new AppUpdateInstallState(
                             AppUpdateInstallState.Status.UPDATE_ACCEPTED,
-                            areAllUpdateFlowsAllowed
-                                    ? AppUpdateInstallState.ErrorCode.NO_ERROR
-                                    : AppUpdateInstallState.ErrorCode.NO_ERROR_PARTIALLY_ALLOWED,
+                            AppUpdateInstallState.ErrorCode.NO_ERROR,
                             AppUpdateInstallState.BYTES_UNKNOWN,
                             AppUpdateInstallState.BYTES_UNKNOWN
                     );

--- a/lib/src/main/java/com/bq/appupdateshelper/AppUpdatesHelper.java
+++ b/lib/src/main/java/com/bq/appupdateshelper/AppUpdatesHelper.java
@@ -90,7 +90,8 @@ public class AppUpdatesHelper {
             this.isListening = true;
             this.installStateListener = installStateListener;
             this.installStateUpdatedListener = new InstallStateUpdatedListener() {
-                @Override public void onStateUpdate(InstallState installState) {
+                @Override
+                public void onStateUpdate(InstallState installState) {
                     AppUpdateInstallState state = new AppUpdateInstallState(installState);
                     Log.d(TAG, "Update status result: " + state.toString());
 
@@ -124,7 +125,8 @@ public class AppUpdatesHelper {
         final Task<AppUpdateInfo> appUpdateInfoTask = manager.getAppUpdateInfo();
 
         appUpdateInfoTask.addOnCompleteListener(new OnCompleteListener<AppUpdateInfo>() {
-            @Override public void onComplete(Task<AppUpdateInfo> task) {
+            @Override
+            public void onComplete(Task<AppUpdateInfo> task) {
                 Exception exception = null;
                 if (task.isSuccessful()) {
                     appUpdateInfo = task.getResult();
@@ -151,17 +153,17 @@ public class AppUpdatesHelper {
     public void startImmediateUpdate(@NonNull Activity activity) {
         if (!isListening)
             throw new IllegalStateException("You must call startListening() " +
-                "before requesting an immediate update");
+                    "before requesting an immediate update");
         if (appUpdateInfo == null)
             throw new IllegalStateException("You must call getAppUpdateInfo() " +
-                "with a successful response before requesting an immediate update");
+                    "with a successful response before requesting an immediate update");
 
         try {
             manager.startUpdateFlowForResult(
-                appUpdateInfo,
-                AppUpdateType.IMMEDIATE,
-                activity,
-                IMMEDIATE_UPDATE_REQUEST_CODE);
+                    appUpdateInfo,
+                    AppUpdateType.IMMEDIATE,
+                    activity,
+                    IMMEDIATE_UPDATE_REQUEST_CODE);
         } catch (IntentSender.SendIntentException e) {
             e.printStackTrace();
         }
@@ -179,17 +181,17 @@ public class AppUpdatesHelper {
     public void startFlexibleUpdate(@NonNull Activity activity) {
         if (!isListening)
             throw new IllegalStateException("You must call startListening() " +
-                "before requesting a flexible update");
+                    "before requesting a flexible update");
         if (appUpdateInfo == null)
             throw new IllegalStateException("You must call getAppUpdateInfo() " +
-                "with a successful response before requesting a flexible update");
+                    "with a successful response before requesting a flexible update");
 
         try {
             manager.startUpdateFlowForResult(
-                appUpdateInfo,
-                AppUpdateType.FLEXIBLE,
-                activity,
-                FLEXIBLE_UPDATE_REQUEST_CODE);
+                    appUpdateInfo,
+                    AppUpdateType.FLEXIBLE,
+                    activity,
+                    FLEXIBLE_UPDATE_REQUEST_CODE);
         } catch (IntentSender.SendIntentException e) {
             e.printStackTrace();
         }
@@ -209,31 +211,39 @@ public class AppUpdatesHelper {
                 case RESULT_CANCELED:
                     if (requestCode == IMMEDIATE_UPDATE_REQUEST_CODE)
                         state = new AppUpdateInstallState(
-                            AppUpdateInstallState.Status.DENIED,
-                            AppUpdateInstallState.ErrorCode.ERROR_INSTALL_NOT_ALLOWED
-                        );
+                                AppUpdateInstallState.Status.DENIED,
+                                AppUpdateInstallState.ErrorCode.ERROR_INSTALL_NOT_ALLOWED,
+                                AppUpdateInstallState.BYTES_UNKNOWN,
+                                AppUpdateInstallState.BYTES_UNKNOWN
+                                );
                     else
                         state = new AppUpdateInstallState(
-                            AppUpdateInstallState.Status.CANCELED,
-                            AppUpdateInstallState.ErrorCode.ERROR_INSTALL_NOT_ALLOWED);
+                                AppUpdateInstallState.Status.CANCELED,
+                                AppUpdateInstallState.ErrorCode.ERROR_INSTALL_NOT_ALLOWED,
+                                AppUpdateInstallState.BYTES_UNKNOWN,
+                                AppUpdateInstallState.BYTES_UNKNOWN);
                     break;
                 case RESULT_IN_APP_UPDATE_FAILED:
                     // We don't know why the update failed, so return an unknown error
                     state = new AppUpdateInstallState(
-                        AppUpdateInstallState.Status.FAILED,
-                        AppUpdateInstallState.ErrorCode.ERROR_UNKNOWN
+                            AppUpdateInstallState.Status.FAILED,
+                            AppUpdateInstallState.ErrorCode.ERROR_UNKNOWN,
+                            AppUpdateInstallState.BYTES_UNKNOWN,
+                            AppUpdateInstallState.BYTES_UNKNOWN
                     );
                     break;
                 default:
                     // If everything goes well, check which updates are allowed and use the proper (no) error code
                     boolean areAllUpdateFlowsAllowed = appUpdateInfo.isUpdateTypeAllowed(AppUpdateType.IMMEDIATE)
-                        && appUpdateInfo.isUpdateTypeAllowed(AppUpdateType.FLEXIBLE);
+                            && appUpdateInfo.isUpdateTypeAllowed(AppUpdateType.FLEXIBLE);
 
                     state = new AppUpdateInstallState(
-                        AppUpdateInstallState.Status.UPDATE_ACCEPTED,
-                        areAllUpdateFlowsAllowed
-                            ? AppUpdateInstallState.ErrorCode.NO_ERROR
-                            : AppUpdateInstallState.ErrorCode.NO_ERROR_PARTIALLY_ALLOWED
+                            AppUpdateInstallState.Status.UPDATE_ACCEPTED,
+                            areAllUpdateFlowsAllowed
+                                    ? AppUpdateInstallState.ErrorCode.NO_ERROR
+                                    : AppUpdateInstallState.ErrorCode.NO_ERROR_PARTIALLY_ALLOWED,
+                            AppUpdateInstallState.BYTES_UNKNOWN,
+                            AppUpdateInstallState.BYTES_UNKNOWN
                     );
                     break;
             }
@@ -256,10 +266,10 @@ public class AppUpdatesHelper {
     public void completeUpdate() {
         if (!isListening)
             throw new IllegalStateException("You must call startListening() " +
-                "before completing an update");
+                    "before completing an update");
         if (appUpdateInfo == null)
             throw new IllegalStateException("You must call getAppUpdateInfo() " +
-                "before completing an update");
+                    "before completing an update");
 
         manager.completeUpdate();
     }


### PR DESCRIPTION
### PR's key points
The PR adds several improvements over the existing library. These are the included changes:
* Upgrade play-core to `1.8.2`.
* Add in-app update stale status (added in `play-core` `1.6.5`)
* Add download progress in install listener (added in `play-core` `1.6.5`)
* Return in-app update priority set via Google Play Developer API (added in `play-core` `1.6.5`)
* More error codes tweaked (added in multiple `play-core` releases)
* Set-up listeners from both `Activity` and `Fragment`
